### PR TITLE
Correction of a bug in the output of training results.

### DIFF
--- a/abc2pyg/logger.py
+++ b/abc2pyg/logger.py
@@ -12,6 +12,9 @@ class Logger(object):
         self.results[run].append(result)
 
     def print_statistics(self, run=None):
+        if len(self.results) == 1:
+            run = 0
+
         if run is not None:
             result = 100 * torch.tensor(self.results[run])
             argmax = result[:, 1].argmax().item()


### PR DESCRIPTION
I see the following warnings:
```
All runs:
/workspace/examples/Gamora/abc2pyg/logger.py:38: UserWarning: std(): degrees of freedom is <= 0. Correction should be 
strictly less than the reduction factor (input numel divided by output numel). (Triggered internally at /opt/pytorch/pytorch/aten/src/ATen/native/ReduceOps.cpp:1827.)
  print(f'Highest Train: {r.mean():.2f} ± {r.std():.2f}')
Highest Train: 99.73 ± nan
/workspace/examples/Gamora/abc2pyg/logger.py:40: UserWarning: std(): degrees of freedom is <= 0. Correction should be
strictly less than the reduction factor (input numel divided by output numel). (Triggered internally at /opt/pytorch/pytorch/aten/src/ATen/native/ReduceOps.cpp:1827.)
  print(f'Highest Valid: {r.mean():.2f} ± {r.std():.2f}')
Highest Valid: 98.91 ± nan
/workspace/examples/Gamora/abc2pyg/logger.py:42: UserWarning: std(): degrees of freedom is <= 0. Correction should be
strictly less than the reduction factor (input numel divided by output numel). (Triggered internally at /opt/pytorch/pytorch/aten/src/ATen/native/ReduceOps.cpp:1827.)
  print(f'  Final Train: {r.mean():.2f} ± {r.std():.2f}')
  Final Train: 99.45 ± nan
/workspace/examples/Gamora/abc2pyg/logger.py:44: UserWarning: std(): degrees of freedom is <= 0. Correction should be
strictly less than the reduction factor (input numel divided by output numel). (Triggered internally at /opt/pytorch/pytorch/aten/src/ATen/native/ReduceOps.cpp:1827.)
  print(f'   Final Test: {r.mean():.2f} ± {r.std():.2f}')
   Final Test: 99.34 ± nan
All runs:
Highest Train: 99.18 ± nan
Highest Valid: 98.91 ± nan
  Final Train: 98.90 ± nan
   Final Test: 98.90 ± nan
```
generated by `abc2pyg/gnn_multitask_v2.py` script. The issue occurs because `r.sdt()` is called on `r` when it contains only a single element. This PR provides a fix for the issue.