### PR TITLE
Correcting meta-information for 'additional node files' keyword.

### DIFF
--- a/abc2pyg/.build_dataset/dataset_pyg.py
+++ b/abc2pyg/.build_dataset/dataset_pyg.py
@@ -128,12 +128,12 @@ class PygNodePropPredDataset(InMemoryDataset):
     def process(self):
         add_inverse_edge = self.meta_info['add_inverse_edge'] == 'True'
 
-        if self.meta_info['additional node files'] == 'None':
+        if self.meta_info['additional node files'] == 'NONE':
             additional_node_files = []
         else:
             additional_node_files = self.meta_info['additional node files'].split(',')
 
-        if self.meta_info['additional edge files'] == 'None':
+        if self.meta_info['additional edge files'] == 'NONE':
             additional_edge_files = []
         else:
             additional_edge_files = self.meta_info['additional edge files'].split(',')

--- a/abc2pyg/.build_dataset/make_master_file.py
+++ b/abc2pyg/.build_dataset/make_master_file.py
@@ -15,8 +15,8 @@ dataset_dict[name]['add_inverse_edge'] = False
 dataset_dict[name]['has_node_attr'] = True
 dataset_dict[name]['has_edge_attr'] = False
 dataset_dict[name]['split'] = 'Random'
-dataset_dict[name]['additional node files'] = 'None'
-dataset_dict[name]['additional edge files'] = 'None'
+dataset_dict[name]['additional node files'] = 'NONE'
+dataset_dict[name]['additional edge files'] = 'NONE'
 dataset_dict[name]['is hetero'] = False
 dataset_dict[name]['binary'] = False
 

--- a/abc2pyg/.build_dataset/save_dataset.py
+++ b/abc2pyg/.build_dataset/save_dataset.py
@@ -467,8 +467,8 @@ class DatasetSaver(object):
         meta_dict['add_inverse_edge'] = 'False'
         meta_dict['has_node_attr'] = str(self.has_node_attr)
         meta_dict['has_edge_attr'] = str(self.has_node_attr)
-        meta_dict['additional node files'] = 'None'
-        meta_dict['additional edge files'] = 'None'
+        meta_dict['additional node files'] = 'NONE'
+        meta_dict['additional edge files'] = 'NONE'
         meta_dict['is hetero'] = str(self.is_hetero)
 
         # save meta-dict for submission

--- a/abc2pyg/dataset_prep/dataset_pyg.py
+++ b/abc2pyg/dataset_prep/dataset_pyg.py
@@ -131,12 +131,12 @@ class PygNodePropPredDataset(InMemoryDataset):
     def process(self):
         add_inverse_edge = self.meta_info['add_inverse_edge'] == 'True'
 
-        if self.meta_info['additional node files'] == 'None':
+        if self.meta_info['additional node files'] == 'NONE':
             additional_node_files = []
         else:
             additional_node_files = self.meta_info['additional node files'].split(',')
 
-        if self.meta_info['additional edge files'] == 'None':
+        if self.meta_info['additional edge files'] == 'NONE':
             additional_edge_files = []
         else:
             additional_edge_files = self.meta_info['additional edge files'].split(',')

--- a/abc2pyg/dataset_prep/make_master_file.py
+++ b/abc2pyg/dataset_prep/make_master_file.py
@@ -24,8 +24,8 @@ def make_master(design_name, num_class=5, new = 0):
         dataset_dict[name]['has_node_attr'] = True
         dataset_dict[name]['has_edge_attr'] = False
         dataset_dict[name]['split'] = 'Random'
-        dataset_dict[name]['additional node files'] = 'None'
-        dataset_dict[name]['additional edge files'] = 'None'
+        dataset_dict[name]['additional node files'] = 'NONE'
+        dataset_dict[name]['additional edge files'] = 'NONE'
         dataset_dict[name]['is hetero'] = False
         dataset_dict[name]['binary'] = False
             
@@ -42,8 +42,8 @@ def make_master(design_name, num_class=5, new = 0):
         dataset_dict[name]['has_node_attr'] = True
         dataset_dict[name]['has_edge_attr'] = False
         dataset_dict[name]['split'] = 'Random'
-        dataset_dict[name]['additional node files'] = 'None'
-        dataset_dict[name]['additional edge files'] = 'None'
+        dataset_dict[name]['additional node files'] = 'NONE'
+        dataset_dict[name]['additional edge files'] = 'NONE'
         dataset_dict[name]['is hetero'] = False
         dataset_dict[name]['binary'] = False
 


### PR DESCRIPTION
In April-May 2024, a new version of `pandas` changed how `None` values in CSV files are handled. Previously, all `None` values were interpreted as text strings, but in the new version, they are treated as delimiters.

As a result, after reading the CSV file, the value of self.meta_info['additional node files'] checked in
```
if self.meta_info['additional node files'] == 'None':
    additional_node_files = []
else:
    additional_node_files = self.meta_info['additional node files'].split(',')
```
is set to `nan` instead of `None` as originally intended, leading to the following crash:
```
Traceback (most recent call last):
  File "/workspace/examples/Gamora/abc2pyg/gnn_multitask_v2.py", line 745, in <module>
    main()
  File "/workspace/examples/Gamora/abc2pyg/gnn_multitask_v2.py", line 604, in main
    dataset_r = PygNodePropPredDataset(name = design_name + '_root')
  File "/workspace/examples/Gamora/abc2pyg/dataset_prep/dataset_pyg.py", line 75, in __init__
    super(PygNodePropPredDataset, self).__init__(self.root, transform, pre_transform)
  File "/usr/local/lib/python3.10/dist-packages/torch_geometric/data/in_memory_dataset.py", line 81, in __init__
    super().__init__(root, transform, pre_transform, pre_filter, log,
  File "/usr/local/lib/python3.10/dist-packages/torch_geometric/data/dataset.py", line 115, in __init__
    self._process()
  File "/usr/local/lib/python3.10/dist-packages/torch_geometric/data/dataset.py", line 260, in _process
    self.process()
  File "/workspace/examples/Gamora/abc2pyg/dataset_prep/dataset_pyg.py", line 137, in process
    additional_node_files = self.meta_info['additional node files'].split(',')
AttributeError: 'float' object has no attribute 'split'
```
